### PR TITLE
Add Netlify redirect for exchange rates API endpoint

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,10 +29,10 @@ status = 200
 force = true
 
 [[redirects]]
-  from = "/api/exchange-rates/*"
-  to = "https://keen-haibt-ecf9f4.netlify.app/api/exchange-rates/:splat"
-  status = 200
-  force = true
+from = "/api/exchange-rates/*"
+to = "https://keen-haibt-ecf9f4.netlify.app/api/exchange-rates/:splat"
+status = 200
+force = true
 
 [[redirects]]
 from = "/files/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,6 +29,12 @@ status = 200
 force = true
 
 [[redirects]]
+  from = "/api/exchange-rates/*"
+  to = "https://keen-haibt-ecf9f4.netlify.app/api/exchange-rates/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
 from = "/files/*"
 to = "https://gifted-shirley-8182af.netlify.app/files/:splat"
 status = 200


### PR DESCRIPTION
## Summary

- Adds a Netlify proxy redirect for `/api/exchange-rates/*` → the currency app's Netlify deployment
- Mirrors the existing `/currency/*` redirect pattern so the portfolio site can expose the exchange rates API endpoint without CORS or mixed-content issues

## Test plan

- [ ] Confirm `/api/exchange-rates/` requests on the portfolio Netlify site are proxied to `keen-haibt-ecf9f4.netlify.app/api/exchange-rates/` with a 200 status
- [ ] Verify existing redirects (currency, files, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)